### PR TITLE
Fix text import

### DIFF
--- a/jupyter-demo.ipynb
+++ b/jupyter-demo.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv(\"wmt20-de-en-full.tsv\", sep=\"\\t\")"
+    "df = pd.read_csv(\"wmt20-de-en-full.tsv\", sep=\"\\t\", quoting=3, keep_default_na=False)  # quoting=3 is to ignore double quotes"
    ]
   },
   {
@@ -84,7 +84,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "zeno",
    "language": "python",
    "name": "python3"
   },
@@ -98,12 +98,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.9"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "40d3a090f54c6569ab1632332b64b2c03c39dcf918b08424e98f38b5ae0af88f"
+    "hash": "3d3165c3d83685c4ad8e0146705088da0f04b298ed1b3478ac14e7341f98150b"
    }
   }
  },


### PR DESCRIPTION
This PR fixes the text import in the example jupyter notebook in two ways:
* Removes the use of quoting. In the tsv format quotes should just be treated as normal characters
* Makes empty strings be treated as empty strings instead of nan